### PR TITLE
remove unused format include, allows build on g++ < 13

### DIFF
--- a/lib/source/spec/opcode.cpp
+++ b/lib/source/spec/opcode.cpp
@@ -1,4 +1,3 @@
-#include <format>
 #include <algorithm>
 #include <ranges>
 #include <disasm/spec/opcode.hpp>

--- a/tests/source/main.cpp
+++ b/tests/source/main.cpp
@@ -1,7 +1,5 @@
 #include <disasm/disasm.hpp>
 
-#include <format>
-
 int main() {
     using namespace disasm;
 


### PR DESCRIPTION
I was trying to build ImHex for Ubuntu 22.04 as there is no release. The only issue I had was with these <format> includes which seem unused. With them removed, I was able to build this lib as well as ImHex on Ubuntu 22.04 using gcc/g++ 12 (format is not available until g++ 13). 

If you use this, you should also be able start releasing ImHex for Ubuntu 22 again if so desired 